### PR TITLE
add link for youtube channel in talks section

### DIFF
--- a/index.ejs.html
+++ b/index.ejs.html
@@ -193,7 +193,8 @@
       <section id="four" class="wrapper alt style1">
         <div class="inner">
           <h2 class="major" id="slides">Last talks &amp; slides</h2>
-          <p>You can find here the slides from the latest talks that have been given during our meetups.</p>
+          <p>You can watch the latest talks in our Youtube channel and you can find here the slides that have been given during our meetups.</p>
+          <a href="https://www.youtube.com/channel/UCy-7CeSbPcmq9hEbm2kZeEw" class="special">LuxembourgJS on Youtube</a>
           <section class="features">
             <% slides.forEach(function(slide){ %>
               <article>

--- a/index.html
+++ b/index.html
@@ -193,7 +193,8 @@
       <section id="four" class="wrapper alt style1">
         <div class="inner">
           <h2 class="major" id="slides">Last talks &amp; slides</h2>
-          <p>You can find here the slides from the latest talks that have been given during our meetups.</p>
+          <p>You can watch the latest talks in our Youtube channel and you can find here the slides that have been given during our meetups.</p>
+          <a href="https://www.youtube.com/channel/UCy-7CeSbPcmq9hEbm2kZeEw" class="special">LuxembourgJS on Youtube</a>
           <section class="features">
             
               <article>


### PR DESCRIPTION
- add link for youtube channel in talks section to be able to retrieve it easily the next time (I search always on it on all web support).

N.B : Link used for youtube channel : [https://www.youtube.com/channel/UCy-7CeSbPcmq9hEbm2kZeEw](https://www.youtube.com/channel/UCy-7CeSbPcmq9hEbm2kZeEw)